### PR TITLE
Small Revision of Typos, Link Targets and Wording

### DIFF
--- a/docs/blog/posts/2024-07-24-maho-is-born.md
+++ b/docs/blog/posts/2024-07-24-maho-is-born.md
@@ -9,7 +9,7 @@ We are thrilled to announce the birth of Maho.
 
 <!-- more -->
 
-We'll give you more details soon, this blog post is just to set this date in stone as a future reminder
+We'll give you more details soon. This blog post is just to set this date in stone as a future reminder.
 
 As we embark on this exciting journey, we invite developers, merchants, and e-commerce enthusiasts to join us
 in shaping the future of Maho. Whether you're looking to migrate or seeking an alternative to existing platforms,

--- a/docs/blog/posts/2024-08-01-a-week-of-maho.md
+++ b/docs/blog/posts/2024-08-01-a-week-of-maho.md
@@ -9,7 +9,7 @@ I want to share an overview of our recent activities and upcoming plans.
 
 <!-- more -->
 
-## Recent revelopments
+## Recent developments
 
 We worked on several minor buy key areas:
 
@@ -20,11 +20,11 @@ We worked on several minor buy key areas:
 
 ## Ongoing major projects
 
-In addition to these accomplishments, we are currently engaged in two substantial projects:
+In addition to these accomplishments, we are currently engaged in two significant projects:
 
 1. **New CLI Tool**: Development of a command-line interface tool comparable to Laravel's Artisan.
 2. **File Structure Innovation**: We are working on a project that will introduce a new approach to file structure in 
-   the M1 platform. While specifics are not yet ready for public disclosure, we anticipate this development to 
+   the M1 platform. While specifics are not yet ready for public disclosure, we expect this development to 
    significantly impact project organization. We estimate approximately two more weeks of development 
    before we can provide more comprehensive information.
 

--- a/docs/blog/posts/2024-08-07-two-weeks-of-maho.md
+++ b/docs/blog/posts/2024-08-07-two-weeks-of-maho.md
@@ -31,18 +31,18 @@ Also, the [roadmap](../../roadmap.md) got some love too.
 
 ## Platform updates
 
-- a lot of cleanup
+- a lot of cleanups
 - a lot of refinements to the new autoloader systems
 - worked on the web installer which should now work
 - worked on the CLI tool to make it functional and to add as many commands as possible
-- ironed out a few things with our new [composer plugin](https://github.com/MahoCommerce/maho-composer-plugin)
-- fixed a couple of bugs with the new [starter project](https://github.com/MahoCommerce/maho-starter) which
-  should now be working
+- ironed out a few things with our new [composer plugin](https://github.com/MahoCommerce/maho-composer-plugin){:target="_blank"}
+- fixed a couple of bugs with the new [starter project](https://github.com/MahoCommerce/maho-starter){:target="_blank"} 
+  which should now be working
 
 ## Closing thoughts
 
-If you want to test Maho, please let us know if it works for you or what problems you find, we are
-committed to solve them in order to make Maho as perfect as possible, as quickly as possible.
+If you want to test Maho, please let us know if it works for you or what problems you find.
+We are committed to solving them to make Maho as perfect as possible, as quickly as possible.
 
 See you next week!  
 Maho rocks! 🚀

--- a/docs/blog/posts/2024-08-14-third-week-of-development.md
+++ b/docs/blog/posts/2024-08-14-third-week-of-development.md
@@ -10,14 +10,14 @@ A quick holiday update from the development team.
 
 This week the work was mainly focused on:
 
-- Adding to our CLI tool as many commands as possi
+- Adding to our CLI tool as many commands as possible
 - Fixing the web installer
 - Making a completely new cron system
 - Bringing the CLI installer into our own CLI tool
 - Removing old features and cleaning up leftover files
 - Rewriting our new autoloaders in order for them to be more portable and easier on PHPStan
-- Making all the workflow run and green again and simplify them as much as possible
+- Making all the workflows run and green again and simplify them as much as possible
 - Writing documentation on the website
 
-That's all for now, be sure to join of newsletter and community!  
+That's all for now, be sure to join the newsletter and community!  
 Maho rocks! 🚀

--- a/docs/blog/posts/2024-08-20-montheversary.md
+++ b/docs/blog/posts/2024-08-20-montheversary.md
@@ -4,7 +4,7 @@ date: 2024-08-20
 
 # The first montheversary
 
-_TLDR_: good feedback after public announcement, a lot of cleanup, and the first
+_TLDR_: good feedback after public announcement, a lot of cleanups, and the first
 security update!
 
 <!-- more -->
@@ -13,28 +13,28 @@ security update!
 
 ## We're public!
 
-In the first month of Maho all the work was done privately, but right before the 30-days mark the time
+In the first month of Maho all the work was done privately, but right before the 30-day mark, the time
 was ready for the **first public announcement**.
 
-It was very well received and **more people joined the github repo and the discord server**.
+It was very well received and **more people joined the GitHub repo and the discord server**.
 
-This is a very good start and I hope more people will join this new jurney!
+This is a great start, and I hope more people will join this new journey!
 
 <div style="clear: both"></div>
 
 ## Software updates
 
-- **A lot of minor cleanup** ("dot" files and directories, htaccess and more)
-- **Changes to the web/CLI installer** (charts/skip_urlvalidation/use_rewrites are enabled by default now
-  and you don't have to click checkbox or type CLI arguments for that. It's 2024, everybody needs
+- **A lot of minor cleanups** ("dot" files and directories, htaccess and more)
+- **Changes to the web/CLI installer** (charts/skip_urlvalidation/use_rewrites are enabled by default now,
+  you don't have to click checkbox or type CLI arguments for that. It's 2024, everybody needs
   rewrites)
 - All logos in the repo are now updated with the Maho graphics
 - **Placeholder images now support SVG format**, which is IMHO a huge improvement
 - **TinyMCE is installed via composer** and no longed bundled inside our repository
-  (this was possible because we own the complete toolchain, in this case the composer plugin).
+  (this was possible because we own the complete toolchain, in this case, the composer plugin).
   Also, thanks to dependabot, I noticed that
-  [TinyMCE has a security issue](https://github.com/advisories/GHSA-5359-pvf2-pw78)
-  which [I already fixed](https://github.com/MahoCommerce/maho/commit/4868c7f2876d99f9a70694be07bf3f8473b16aea).
+  [TinyMCE has a security issue](https://github.com/advisories/GHSA-5359-pvf2-pw78){:target="_blank"}
+  which [I already fixed](https://github.com/MahoCommerce/maho/commit/4868c7f2876d99f9a70694be07bf3f8473b16aea){:target="_blank"}.
 - Our website now has the complete (and fixed) porting of the old [REST/SOAP API documentation](../../api/soap.md),
   this was a big task, 4 full days of work, but I think it was about time we could use that great documentation
   that really needed some love.
@@ -49,9 +49,9 @@ This is a very good start and I hope more people will join this new jurney!
 It was a great week and a great month for **Maho**, and I hope we continue on this trajectory.  
 I'm thinking about write on the blog every other week, instead of weekly, because in the next few
 weeks I'll also have to focus on paid projects and I won't be able to do full time work on Maho.
-**I would love to dedicate myself completely to this project but that would be possible only with
+**I would love to dedicate myself completely to this project, but that would be possible only with
 enough sponsorships.** Sponsoring/partnership options will be available in the future, but if you find
-my work valuable please [check my github profile for options](https://github.com/fballiano) that
+my work valuable please [check my GitHub profile for options](https://github.com/fballiano){:target="_blank"} that
 are available now.
 
 Till next time... Maho rocks! 🚀

--- a/docs/cli-tool.md
+++ b/docs/cli-tool.md
@@ -52,23 +52,23 @@ Available commands:
   sys:timezones               Get all available timezones
 ```
 
-This tool is inspired by [Laravel Artisan](https://laravel.com/docs/11.x/artisan),
-[n98-magerun](https://github.com/netz98/n98-magerun), and it was created using the awesome
-[Symfony Console](https://symfony.com/doc/current/console.html) component.
+This tool is inspired by [Laravel Artisan](https://laravel.com/docs/11.x/artisan){:target="_blank"},
+[n98-magerun](https://github.com/netz98/n98-magerun){:target="_blank"}, and it was created using the awesome
+[Symfony Console](https://symfony.com/doc/current/console.html){:target="_blank"} component.
 
 ## Available commands
 
 The list of the built-in commands is growing rapidly, at the moment yon can either run
 `./maho` within your Maho based project or you can check
-[Maho CLI commands folder](https://github.com/MahoCommerce/maho/tree/main/lib/MahoCLI/Commands)
+[Maho CLI commands directory](https://github.com/MahoCommerce/maho/tree/main/lib/MahoCLI/Commands){:target="_blank"}
 within our GitHub repository.
 
 All commands should be self-explanatory, also thanks to the inline descriptions.
 
 ## Add your custom commands
 
-1. Create `lib/MahoCLI/Commands` in the main folder of your project
-2. Create your command file, eg `MyCustomCommand.php` in `lib/MahoCLI/Commands` just like:
+1. Create `lib/MahoCLI/Commands` in the main directory of your project
+2. Create your command file, e.g. `MyCustomCommand.php` in `lib/MahoCLI/Commands` just like:
 ```php
 <?php
 

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -8,7 +8,7 @@ We look forward to your contributions!
 
 **We are committed to building a healthy and respectful community.**  
 All contributors and participants in the Maho project are expected to adhere to our
-[Code of Conduct](https://github.com/MahoCommerce/maho?tab=coc-ov-file).
+[Code of Conduct](https://github.com/MahoCommerce/maho?tab=coc-ov-file){:target="_blank"}.
 This code outlines our expectations for behavior within the community, as well as the consequences for unacceptable behavior.
 
 Please review and follow our Code of Conduct in all your interactions within the Maho community,
@@ -21,24 +21,24 @@ We look forward to growing a positive, inclusive, and productive community toget
 
 We encourage you to share your ideas for improvements or new features:
 
-1. Visit the [Discussions](https://github.com/your-org/maho/discussions) section of [our GitHub repository](https://github.com/MahoCommerce/maho).
-2. [Look for the "Ideas" category](https://github.com/MahoCommerce/maho/discussions/categories/ideas) and check if your ideas has already been submitted.
-3. [Create a new discussion](https://github.com/MahoCommerce/maho/discussions/new?category=ideas) to propose your idea or feature request.
+1. Visit the [Discussions](https://github.com/MahoCommerce/maho/discussions){:target="_blank"} section of [our GitHub repository](https://github.com/MahoCommerce/maho){:target="_blank"}.
+2. [Look for the "Ideas" category](https://github.com/MahoCommerce/maho/discussions/categories/ideas){:target="_blank"} and check if your ideas have already been submitted.
+3. [Create a new discussion](https://github.com/MahoCommerce/maho/discussions/new?category=ideas){:target="_blank"} to propose your idea or feature request.
 4. Engage with the community to refine and discuss your proposal.
 
 ## Reporting bugs
 
 If you encounter a bug while using Maho:
 
-1. Check the [issues section](https://github.com/MahoCommerce/maho/issues) to see if it has already been reported.
-2. If not, [create a new issue](https://github.com/MahoCommerce/maho/issues/new) with a clear title and detailed description of the problem.
+1. Check the [Issues](https://github.com/MahoCommerce/maho/issues){:target="_blank"} section to see if it has already been reported.
+2. If not, [create a new issue](https://github.com/MahoCommerce/maho/issues/new){:target="_blank"} with a clear title and detailed description of the problem.
 3. Include steps to reproduce the bug, expected behavior, and any relevant error messages or screenshots.
 
 ## General discussions
 
 For broader topics or questions:
 
-1. Start a new thread in the [Discussions](https://github.com/MahoCommerce/maho/discussions) section.
+1. Start a new thread in the [Discussions](https://github.com/MahoCommerce/maho/discussions){:target="_blank"} section.
 2. Choose the appropriate category for your topic.
 3. Engage respectfully with other community members.
 
@@ -46,7 +46,7 @@ For broader topics or questions:
 
 Need a quick answer or want to chat with other Maho contributors?
 
-Join our [Discord server](https://discord.gg/dWgcVUFTrS) for real-time discussions and support.
+Join our [Discord server](https://discord.gg/dWgcVUFTrS){:target="_blank"} for real-time discussions and support.
 
 ## Contributing code
 
@@ -62,10 +62,10 @@ and pull requests with tests will be prioritized.
 
 Improvements to documentation are always welcome. Our documentation is hosted in a separate repository:
 
-1. Visit the [Maho's website repository](https://github.com/MahoCommerce/mahocommerce.com).
-2. The documentation is built using mkdocs-material.
+1. Visit the [Maho's website repository](https://github.com/MahoCommerce/mahocommerce.com){:target="_blank"}.
+2. The documentation is built using `mkdocs-material`.
 3. Before contributing, please check the README.md file in the repository for specific instructions on how to run and test the documentation locally.
-4. Fork the [documentation repository](https://github.com/MahoCommerce/mahocommerce.com).
+4. Fork the [documentation repository](https://github.com/MahoCommerce/mahocommerce.com){:target="_blank"}.
 5. Make your changes to the documentation.
 6. Test your changes locally to ensure they render correctly.
-7. [Submit a pull request to the documentation repository](https://github.com/MahoCommerce/mahocommerce.com/pulls) (not the main Maho framework repository).
+7. [Submit a pull request to the documentation repository](https://github.com/MahoCommerce/mahocommerce.com/pulls){:target="_blank"} (not the main Maho framework repository).

--- a/docs/community/get-involved.md
+++ b/docs/community/get-involved.md
@@ -4,7 +4,7 @@ That's where Maho comes in – and where you can make a real difference.
 We're building more than just another e-commerce platform.  
 Maho aims to be the go-to solution for businesses that demand control, flexibility, performance and simplicity.
 
-By participating to Maho, you're not just contributing to a project – you are putting your dent in the furure of e-commerce.
+By participating in Maho, you're not just contributing to a project – you are putting your dent in the future of e-commerce.
 
 [Join our community on Discord :fontawesome-brands-discord:](https://discord.gg/dWgcVUFTrS){:target="_blank" .md-button .md-button--primary .md-consent__controls}
 [Check our contributing guidelines](contributing.md){.md-button .md-button--primary .md-consent__controls}

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -1,6 +1,6 @@
 ## Deploy to production
 
-When you deploy a Maho project in production, you need to setup cron this way:
+When you deploy a Maho project in production, you need to set up cron this way:
 
 ```cron
 */5 * * * * cd /var/www/mahoproject; php ./maho cron:run default >/dev/null 2>&1
@@ -78,7 +78,7 @@ these two commands:
 
 ## Test locally
 
-When developing a Maho project locally, you don't need to setup cron, but you may
+When developing a Maho project locally, you don't need to set up cron, but you may
 want to run a specific cron job.
 
 This can be done passing the `job_code` you want to execute to `./maho cron:run`, like:
@@ -90,5 +90,5 @@ core_email_queue_send_all executed successfully
 
 !!! note
     If there's a record in the `cron_schedule` table for the specified `job_code` with status
-    of `pending, that record will be "burnt", otherwise no record will be created but the job
+    of `pending`, that record will be "burnt" otherwise no record will be created but the job
     will be executed anyway.

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -6,7 +6,7 @@ Maho is built on the M1 platform, specifically:
 - OpenMage, fork of Magento 1 (2019 - present)
 - Maho, fork of unreleased OpenMage v21 (2024 - present)
 
-Differences between Maho and Magento 1 because are documented in
+Differences between Maho and Magento 1 are documented in
 [OpenMage's readme](https://github.com/openmage/magento-lts/?tab=readme-ov-file#between-magento-1945-and-openmage-19x){:target="_blank"}.
 
 ## Differences between Maho and OpenMage
@@ -18,7 +18,7 @@ Differences between Maho and Magento 1 because are documented in
 The first task we wanted to develop was a complete overhaul of the store's project structure, without the need for the
 original M1 composer plugin to copy (and duplicate) all the files from the core to the project's root directory.
 
-This allows for a modern and lean project structure, like any other PHP based project you can work on since quite
+This allows for a modern and lean project structure, like any other PHP-based project you can work on since quite
 some years.
 
 **In this picture you see a basic Maho project right after installation.** Pretty clean right?
@@ -29,14 +29,14 @@ Whatever is in your local project overrides whatever is in composer-installed mo
 
 ### Built-in command line tool
 
-With previous M1 based project you had some basic scripts in the `shell/` directory but everybody was relying on
+With previous M1-based project you had some basic scripts in the `shell/` directory but everybody was relying on
 [MageRun](https://magerun.net/){:target="_blank"} for anything slightly more advanced.
 
 To know more, check the [complete documentation of Maho's CLI tool](cli-tool.md).
 
 ### Complete control of the toolchain
 
-We think that having core components of the toolchain that are unmaintained and/or owned by a 3rd party is a
+We think that having core components of the toolchain that are unmaintained and/or owned by a third party is a
 problem for a quick and effective development of the whole platform.
 
 This is why, at Maho, we decided to maintain internally both the [CLI tool](cli-tool.md), the
@@ -50,5 +50,5 @@ every Maho project will have the modern theme for the backend.
 
 ### Other differences
 
-There are many more minor differences, it's difficult to list them all, please refer to our changelog and our release
+There are many more minor differences, it's challenging to list them all, please refer to our changelog and our release
 notes for a complete list release-by-release.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 # Getting Started
 
 !!! danger ""
-    Maho's is under heavy development so, at this moment, we suggest you to install it only if you want to
+    Maho is under heavy development, so currently we suggest that you install it only if you want to
     see what's going on and to give it a try.
 
 ## System requirements
@@ -9,7 +9,7 @@
 - PHP 8.2+
 - Apache/Nginx/Caddy/FrankenPHP[^1]
 - MySQL 5.7+ (8.0+ recommended) or MariaDB
-- `patch` command 2.7+ (or `gpatch` on MacOS/HomeBrew)
+- `patch` command 2.7+ (or `gpatch` on macOS/HomeBrew)
 
 ## Create your project
 
@@ -18,12 +18,12 @@ composer create-project -s dev mahocommerce/maho-starter yourproject
 ```
 
 !!! info
-    - `-s dev` is a temporary flag that will be removed when the final release will be ready
-    - `yourproject` is the name of the folder where you want to create the project
+    - `-s dev` is a temporary flag that will be removed when the final release is ready
+    - `yourproject` is the name of the directory where you want to create the project
 
 ## Configure your web server
 
-With Maho you have to point your web server's document root to the `/pub` folder.  
+With Maho you have to point your web server's document root to the `/pub` directory.  
 This is a necessary step to ensure the highest level of security.
 
 Alternatively, if you're just developing on your computer, you can run `./maho serve` 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@
 <h2 id="homeh2">#StrongRoots #ForwardThinking #FamiliarYetDifferent</h2>
 
 **Maho** is a free and **open source ecommerce platform**, created in 2024 by
-[a former maintainer of OpenMage](https://fabrizioballiano.com).
+[a former maintainer of OpenMage](https://fabrizioballiano.com){:target="_blank"}.
 Based on the M1 platform, Maho grants **hyper stability** and a **vast ecosystem of 
 modules and extensions**.
 
@@ -18,7 +18,7 @@ modules and extensions**.
 new features, modern developer-friendly architecture, zero hassles and zero baggage**.
 
 We will try to make Maho as backward compatible as possible, but we won't let the ghosts of the
-past to stop the innovation we need to bring to developers and store owners.
+past stop the innovation we need to bring to developers and store owners.
 
 ### A clear ecommerce platforms landscape
 

--- a/docs/origins.md
+++ b/docs/origins.md
@@ -20,8 +20,8 @@ the way for future innovations in the e-commerce space.
 
 ## Meaning and pronunciation of Maho
 
-"Maho" ([pronounced as "mah-hoh"](https://www.ingles.com/pronunciacion/majo)) draws inspiration from various
-cultural meanings:
+"Maho" ([pronounced as "mah-hoh"](https://www.ingles.com/pronunciacion/majo){:target="_blank"}) draws inspiration
+from various cultural meanings:
 
 - **Maho (or Majo) is the name given to the ancient indigenous people of Lanzarote and Fuerteventura**,
   islands in the Atlantic archipelago of the Canary Islands (Spain), home of this project's maintainer.  

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,11 +1,12 @@
 We think that it's extremely important, both for the team and the users, to have a clear and public roadmap.
-That's why we manage it through github projets.
+That's why we manage it through GitHub projects.
 
 [Check Maho's public roadmap](https://github.com/orgs/MahoCommerce/projects/2/views/1){:target="_blank" .md-button .md-button--primary}
 
 ## Make it your own
 
-There's no open source without the community, if you have ideas for improvements or new features, 
-we encourage you to share them. You can post your ideas in the Ideas section of our GitHub Discussions:
+There's no open source without the community.
+If you have ideas for improvements or new features, we encourage you to share them.
+You can post your ideas in the Ideas section of our GitHub Discussions:
 
 [Post your idea](https://github.com/MahoCommerce/maho/discussions/categories/ideas){:target="_blank" .md-button .md-button--primary}

--- a/docs/robotstxt.md
+++ b/docs/robotstxt.md
@@ -2,7 +2,7 @@
 how to crawl pages on their website. The file uses the
 [Robots Exclusion Protocol](https://en.wikipedia.org/wiki/Robots.txt){:target="_blank"},
 which is a protocol with a small set of commands that can be used to indicate access to your site by section and by 
-specific kinds of web crawlers (such as mobile crawlers vs desktop crawlers).
+specific kinds of web crawlers (such as mobile crawlers vs. desktop crawlers).
 
 ## Why is robots.txt important for e-commerce websites?
 


### PR DESCRIPTION
# Description

This PR
- fixes some typos.
- adds `target="_blank"` to external links to keep the focus on the website and not leave it unplanned when clicking on links.
- simplifies and standardizes the wording of some terms.
- splits a few very long sentences into shorter ones.

The `api` directory is excluded from this PR. There will be separate PRs for that.
The changes in this PR are just suggestions. I just wanted to add some feedback and appreciation to the website. :)

# Type of change

- Refactor
- Fix
